### PR TITLE
Update order management URL injection

### DIFF
--- a/customerservice/src/main/java/com/microservico/customerservice/service/PedidoClient.java
+++ b/customerservice/src/main/java/com/microservico/customerservice/service/PedidoClient.java
@@ -2,7 +2,6 @@ package com.microservico.customerservice.service;
 
 import com.microservico.customerservice.dto.request.PedidoDtoRequest;
 import com.microservico.customerservice.dto.response.PedidoDtoResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -10,11 +9,10 @@ import org.springframework.web.client.*;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PedidoClient {
 
     @Value("${order.management.url}")
-    private final String orderManagementUrl;
+    private String orderManagementUrl;
 
     public PedidoDtoResponse criarPedido(PedidoDtoRequest request) {
 

--- a/customerservice/src/main/resources/application.properties
+++ b/customerservice/src/main/resources/application.properties
@@ -6,6 +6,6 @@ spring.datasource.password=customerpass
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
-order.management.url=http://order-management:8080
+order.management.url=http://localhost:8080
 
 server.port=8081


### PR DESCRIPTION
## Summary
- inject `order.management.url` via `@Value` instead of constructor param
- set local default URL in `customerservice` properties

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426e5a24ac8332a9aafcee7dc9c031